### PR TITLE
feat: add ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.256  # Usa la última versión de ruff
+    hooks:
+      - id: ruff

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,4 @@
+[tool.ruff]
+line-length = 88  
+select = ["E", "F", "B", "I"]  
+ignore = ["E501"]


### PR DESCRIPTION
- Install Ruff as the primary linter for the project.
- Add basic configuration in `.ruff.toml` for linting standards.
- Ensure Ruff runs on all Python files in the project.
- Optional: Add pre-commit hook for Ruff to automatically check code before commits.
